### PR TITLE
Fix: 클라이언트 로직에서 Message 객체 수신 스레드 생성

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
+    <file url="file://$PROJECT_DIR$/src/main/java/client/QuizClient.java" charset="UTF-8" />
+  </component>
+</project>

--- a/src/main/java/client/QuizClient.java
+++ b/src/main/java/client/QuizClient.java
@@ -1,5 +1,6 @@
 package client;
 
+import client.thread.MessageReceiver;
 import client.ui.InitialUI;
 
 import java.io.*;
@@ -16,8 +17,11 @@ public class QuizClient {
             out = new ObjectOutputStream(socket.getOutputStream());
             in = new ObjectInputStream(socket.getInputStream());
 
+
+            MessageReceiver receiver = new MessageReceiver(in);
+            receiver.start();
             // 초기 화면을 보여줌
-            new InitialUI(socket, out, in);
+            new InitialUI(socket, out, receiver);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/client/thread/MessageReceiver.java
+++ b/src/main/java/client/thread/MessageReceiver.java
@@ -1,0 +1,42 @@
+package client.thread;
+
+import protocol.Message;
+
+import java.io.ObjectInputStream;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class MessageReceiver extends Thread {
+    private final ObjectInputStream in;
+    private final BlockingQueue<Message> messageQueue;
+    private volatile boolean running = true;
+
+    public MessageReceiver(ObjectInputStream in) {
+        this.in = in;
+        this.messageQueue = new LinkedBlockingQueue<>();
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (running) {
+                Message message = (Message) in.readObject();
+                System.out.println(message.getType());
+                messageQueue.put(message); // 읽은 메시지를 큐에 추가
+            }
+        } catch (Exception e) {
+            if (running) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public Message takeMessage() throws InterruptedException {
+        return messageQueue.take(); // 큐에서 메시지를 가져옴
+    }
+
+    public void stopReceiver() {
+        running = false;
+        interrupt();
+    }
+}

--- a/src/main/java/client/ui/GameCustomizeUI.java
+++ b/src/main/java/client/ui/GameCustomizeUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.customize.CooperationCustomizeUI;
 import client.ui.customize.SpeedQuizCustomizeUI;
 import client.ui.customize.versusCustomizeUI.VersusCustomizeUI;
@@ -14,7 +15,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class GameCustomizeUI {
-    public GameCustomizeUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String loginUserId) {
+    public GameCustomizeUI(Socket socket, ObjectOutputStream out, String loginUserId, MessageReceiver receiver) {
         JFrame frame = new JFrame("Game Customize");
         frame.setSize(500, 400);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -75,7 +76,7 @@ public class GameCustomizeUI {
         backButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new MenuUI(socket, out, in, loginUserId);  // MenuUI로 돌아감
+                new MenuUI(socket, out, loginUserId, receiver);  // MenuUI로 돌아감
             }
         });
 
@@ -83,21 +84,21 @@ public class GameCustomizeUI {
         speedQuizButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new SpeedQuizCustomizeUI(socket, out, in, loginUserId);
+                new SpeedQuizCustomizeUI(socket, out, loginUserId, receiver);
             }
         });
 
         cooperationModeButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new CooperationCustomizeUI(socket, out, in, loginUserId);
+                new CooperationCustomizeUI(socket, out, loginUserId, receiver);
             }
         });
 
         versusModeButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new VersusCustomizeUI(socket, out, in, loginUserId);
+                new VersusCustomizeUI(socket, out, loginUserId, receiver);
             }
         });
     }

--- a/src/main/java/client/ui/GameModeUI.java
+++ b/src/main/java/client/ui/GameModeUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.icon.ArrowIcon;
 import javax.swing.*;
 import java.awt.*;
@@ -10,7 +11,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class GameModeUI {
-    public GameModeUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String loginUserId) {
+    public GameModeUI(Socket socket, ObjectOutputStream out, String loginUserId, MessageReceiver receiver) {
         JFrame frame = new JFrame("Game Modes");
         frame.setSize(500, 400);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -68,7 +69,7 @@ public class GameModeUI {
         backButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new LoginUI(socket, out, in);  // LoginUI로 돌아감
+                new LoginUI(socket, out, receiver);  // LoginUI로 돌아감
             }
         });
 
@@ -76,21 +77,21 @@ public class GameModeUI {
         speedQuizButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new RoomListUI(socket, out, in, "Speed Quiz Mode", loginUserId);
+                new RoomListUI(socket, out, "Speed Quiz Mode", loginUserId, receiver);
             }
         });
 
         cooperationModeButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new RoomListUI(socket, out, in, "Cooperation Mode", loginUserId);
+                new RoomListUI(socket, out, "Cooperation Mode", loginUserId, receiver);
             }
         });
 
         versusModeButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new RoomListUI(socket, out, in, "Versus Mode", loginUserId);
+                new RoomListUI(socket, out, "Versus Mode", loginUserId, receiver);
             }
         });
     }

--- a/src/main/java/client/ui/InitialUI.java
+++ b/src/main/java/client/ui/InitialUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.LoginUI;
 import client.ui.RegisterUI;
 
@@ -12,7 +13,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class InitialUI {
-    public InitialUI(Socket socket, ObjectOutputStream out, ObjectInputStream in) {
+    public InitialUI(Socket socket, ObjectOutputStream out, MessageReceiver receiver) {
         JFrame frame = new JFrame("Quiz Game");
         frame.setSize(500, 400);  // 창 크기 조절
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -50,14 +51,14 @@ public class InitialUI {
         loginButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new LoginUI(socket, out, in);
+                new LoginUI(socket, out, receiver);
             }
         });
 
         registerButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new RegisterUI(socket, out, in);
+                new RegisterUI(socket, out, receiver);
             }
         });
     }

--- a/src/main/java/client/ui/LoginUI.java
+++ b/src/main/java/client/ui/LoginUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
 import javax.swing.*;
@@ -11,7 +12,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class LoginUI {
-    public LoginUI(Socket socket, ObjectOutputStream out, ObjectInputStream in) {
+    public LoginUI(Socket socket, ObjectOutputStream out, MessageReceiver receiver) {
         JFrame frame = new JFrame("Login");
         frame.setSize(500, 400);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -64,7 +65,7 @@ public class LoginUI {
         backButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new InitialUI(socket, out, in);  // InitialUI로 돌아감
+                new InitialUI(socket, out, receiver);  // InitialUI로 돌아감
             }
         });
 
@@ -76,13 +77,13 @@ public class LoginUI {
                 Message loginMessage = new Message("login")
                         .setUserId(id)
                         .setPassword(password);
-                sendMessage(loginMessage, out, in);
+                sendMessage(loginMessage, out, receiver);
 
                 if ("Login successful".equals(loginMessage.getData())) {
                     JOptionPane.showMessageDialog(null, "로그인 성공");
                     frame.dispose();
                     String loginUserId = loginMessage.getUserId();
-                    new MenuUI(socket, out, in, loginUserId);
+                    new MenuUI(socket, out, loginUserId, receiver);
                 } else {
                     JOptionPane.showMessageDialog(null, "로그인 실패: " + loginMessage.getData());
                 }
@@ -90,10 +91,10 @@ public class LoginUI {
         });
     }
 
-    private void sendMessage(Message message, ObjectOutputStream out, ObjectInputStream in) {
+    private void sendMessage(Message message, ObjectOutputStream out, MessageReceiver receiver) {
         try {
             out.writeObject(message);
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
             message.setData(response.getData());
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/client/ui/MenuUI.java
+++ b/src/main/java/client/ui/MenuUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.icon.ArrowIcon;
 
 import javax.swing.*;
@@ -11,7 +12,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class MenuUI {
-    public MenuUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String loginUserId) {
+    public MenuUI(Socket socket, ObjectOutputStream out, String loginUserId, MessageReceiver receiver) {
         JFrame frame = new JFrame("Menu");
         frame.setSize(500, 400);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -72,21 +73,21 @@ public class MenuUI {
         playGameButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new GameModeUI(socket, out, in, loginUserId);
+                new GameModeUI(socket, out, loginUserId, receiver);
             }
         });
 
         customizeGameButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new GameCustomizeUI(socket, out, in, loginUserId); // GameCustomizeUI로 이동
+                new GameCustomizeUI(socket, out, loginUserId, receiver); // GameCustomizeUI로 이동
             }
         });
 
         logoutButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new LoginUI(socket, out, in); // LogoutUI로 이동
+                new LoginUI(socket, out, receiver); // LogoutUI로 이동
             }
         });
     }

--- a/src/main/java/client/ui/RegisterUI.java
+++ b/src/main/java/client/ui/RegisterUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
 import javax.swing.*;
@@ -11,7 +12,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class RegisterUI {
-    public RegisterUI(Socket socket, ObjectOutputStream out, ObjectInputStream in) {
+    public RegisterUI(Socket socket, ObjectOutputStream out, MessageReceiver receiver) {
         JFrame frame = new JFrame("Register");
         frame.setSize(500, 450);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -72,7 +73,7 @@ public class RegisterUI {
         backButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new InitialUI(socket, out, in);  // InitialUI로 돌아감
+                new InitialUI(socket, out, receiver);  // InitialUI로 돌아감
             }
         });
 
@@ -86,12 +87,12 @@ public class RegisterUI {
                         .setUserId(id)
                         .setPassword(password)
                         .setUsername(name);
-                sendMessage(registerMessage, out, in);
+                sendMessage(registerMessage, out, receiver);
 
                 if ("Registration successful".equals(registerMessage.getData())) {
                     JOptionPane.showMessageDialog(null, "Registration successful");
                     frame.dispose();
-                    new InitialUI(socket, out, in);
+                    new InitialUI(socket, out, receiver);
                 } else {
                     JOptionPane.showMessageDialog(null, "Registration failed: " + registerMessage.getData());
                 }
@@ -99,10 +100,10 @@ public class RegisterUI {
         });
     }
 
-    private void sendMessage(Message message, ObjectOutputStream out, ObjectInputStream in) {
+    private void sendMessage(Message message, ObjectOutputStream out, MessageReceiver receiver) {
         try {
             out.writeObject(message);
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
             message.setData(response.getData());
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/client/ui/RoomAddUI.java
+++ b/src/main/java/client/ui/RoomAddUI.java
@@ -1,5 +1,6 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
 
@@ -12,14 +13,12 @@ import java.net.Socket;
 public class RoomAddUI {
     private Socket socket;
     private ObjectOutputStream out;
-    private ObjectInputStream in;
     private String gameMode;
     private String userId;
 
-    public RoomAddUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String gameMode, String userId) {
+    public RoomAddUI(Socket socket, ObjectOutputStream out, String gameMode, String userId, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.gameMode = gameMode;
         this.userId = userId;
 
@@ -82,7 +81,7 @@ public class RoomAddUI {
         // 뒤로가기 버튼 동작
         backButton.addActionListener(e -> {
             frame.dispose();
-            new RoomListUI(socket, out, in, gameMode, userId); // RoomListUI로 돌아감
+            new RoomListUI(socket, out, gameMode, userId, receiver); // RoomListUI로 돌아감
         });
 
         // 방 생성 버튼 동작
@@ -99,11 +98,11 @@ public class RoomAddUI {
                         .setCapacity(capacity);  // 인원 제한 전송
                 out.writeObject(createRoomMessage);
 
-                Message response = (Message) in.readObject();
+                Message response = receiver.takeMessage();
                 if ("createRoomSuccess".equals(response.getType())) {
                     JOptionPane.showMessageDialog(null, "방 생성 성공!");
                     frame.dispose();
-                    new RoomListUI(socket, out, in, gameMode, userId);
+                    new RoomListUI(socket, out, gameMode, userId, receiver);
                 } else {
                     JOptionPane.showMessageDialog(null, "방 생성 실패: " + response.getData());
                 }

--- a/src/main/java/client/ui/RoomListUI.java
+++ b/src/main/java/client/ui/RoomListUI.java
@@ -1,7 +1,8 @@
 package client.ui;
 
+import client.thread.MessageReceiver;
 import client.ui.gamemode.CooperationUI;
-import client.ui.gamemode.SpeedQuizUI;
+import client.ui.gamemode.speedQuiz.SpeedQuizUI;
 import client.ui.gamemode.versusUI.VersusUI;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
@@ -19,15 +20,13 @@ import java.util.Map;
 public class RoomListUI {
     private Socket socket;
     private ObjectOutputStream out;
-    private ObjectInputStream in;
     private String gameMode;
     private String userId;
     private Map<Integer, String> roomMap;
 
-    public RoomListUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String gameMode, String loginUserId) {
+    public RoomListUI(Socket socket, ObjectOutputStream out, String gameMode, String loginUserId, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.gameMode = gameMode;
         this.userId = loginUserId;
         this.roomMap = new HashMap<>();
@@ -61,7 +60,7 @@ public class RoomListUI {
         panel.add(titleLabel);
 
         // 서버로부터 방 리스트 가져오기
-        fetchRoomListFromServer();
+        fetchRoomListFromServer(receiver);
 
         // 방 리스트 표시
         DefaultListModel<String> listModel = new DefaultListModel<>();
@@ -79,7 +78,7 @@ public class RoomListUI {
                 String selectedRoomName = roomList.getSelectedValue();
                 int selectedRoomId = getRoomIdByName(selectedRoomName);
                 if (selectedRoomId != -1) {
-                    enterRoom(frame, selectedRoomId);
+                    enterRoom(frame, selectedRoomId, receiver);
                 }
             }
         });
@@ -97,7 +96,7 @@ public class RoomListUI {
             @Override
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new RoomAddUI(socket, out, in, gameMode, loginUserId);
+                new RoomAddUI(socket, out, gameMode, loginUserId, receiver);
             }
         });
 
@@ -106,32 +105,33 @@ public class RoomListUI {
         backButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 frame.dispose();
-                new GameModeUI(socket, out, in, loginUserId);
+                new GameModeUI(socket, out, loginUserId, receiver);
             }
         });
     }
 
-    private void enterRoom(JFrame frame, int roomId) {
+    private void enterRoom(JFrame frame, int roomId, MessageReceiver receiver) {
         try {
             Message enterRequest = new Message("enterRoom")
                     .setUserId(userId)
                     .setData(String.valueOf(roomId));
             out.writeObject(enterRequest);
 
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
             if ("enterRoomSuccess".equals(response.getType())) {
+                String masterId = response.getRoomMaster();
                 switch (gameMode) {
                     case "Speed Quiz Mode":
                         frame.dispose();
-                        new SpeedQuizUI(socket, out, in, roomId, userId);
+                        new SpeedQuizUI(socket, out, roomId, userId, masterId, receiver);
                         break;
                     case "Versus Mode":
                         frame.dispose();
-                        new VersusUI(socket, out, in, roomId, userId);
+                        new VersusUI(socket, out, roomId, userId, receiver);
                         break;
                     case "Cooperation Mode":
                         frame.dispose();
-                        new CooperationUI(socket, out, in, roomId, userId);
+                        new CooperationUI(socket, out, roomId, userId, receiver);
                         break;
                     default:
                         JOptionPane.showMessageDialog(null, "알 수 없는 게임 모드입니다.");
@@ -154,8 +154,7 @@ public class RoomListUI {
         return -1;
     }
 
-    private void fetchRoomListFromServer() {
-
+    private void fetchRoomListFromServer(MessageReceiver receiver) {
         try {
             Message request = new Message("fetchRoomList")
                     .setUserId(userId)
@@ -163,13 +162,19 @@ public class RoomListUI {
             out.writeObject(request);
             out.flush();
 
-            Message response = (Message) in.readObject();
-            roomMap = response.getRoomNames();
+            // MessageReceiver에서 메시지를 가져옴
+            Message response = receiver.takeMessage();
+
+            if ("fetchRoomListResponse".equals(response.getType())) {
+                roomMap = response.getRoomNames();
+            } else {
+                roomMap.put(-1, "Invalid response");
+            }
 
         } catch (Exception e) {
             e.printStackTrace();
-            roomMap.put(-1, "Failed to load rooms123");
+            roomMap.put(-1, "Failed to load rooms");
         }
-
     }
+
 }

--- a/src/main/java/client/ui/customize/CooperationCustomizeUI.java
+++ b/src/main/java/client/ui/customize/CooperationCustomizeUI.java
@@ -1,10 +1,12 @@
 package client.ui.customize;
 
+import client.thread.MessageReceiver;
+
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class CooperationCustomizeUI {
-    public CooperationCustomizeUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String loginUserId) {
+    public CooperationCustomizeUI(Socket socket, ObjectOutputStream out, String loginUserId, MessageReceiver receiver) {
     }
 }

--- a/src/main/java/client/ui/customize/SpeedQuizCustomizeUI.java
+++ b/src/main/java/client/ui/customize/SpeedQuizCustomizeUI.java
@@ -1,10 +1,12 @@
 package client.ui.customize;
 
+import client.thread.MessageReceiver;
+
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 
 public class SpeedQuizCustomizeUI {
-    public SpeedQuizCustomizeUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String loginUserId) {
+    public SpeedQuizCustomizeUI(Socket socket, ObjectOutputStream out, String loginUserId, MessageReceiver receiver) {
     }
 }

--- a/src/main/java/client/ui/customize/versusCustomizeUI/VersusCustomizeGetQuizUI.java
+++ b/src/main/java/client/ui/customize/versusCustomizeUI/VersusCustomizeGetQuizUI.java
@@ -1,5 +1,6 @@
 package client.ui.customize.versusCustomizeUI;
 
+import client.thread.MessageReceiver;
 import client.ui.MenuUI;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
@@ -15,17 +16,18 @@ import java.net.Socket;
 public class VersusCustomizeGetQuizUI {
     private final Socket socket;
     private final ObjectOutputStream out;
-    private final ObjectInputStream in;
     private final String userId;
     private int num;
     private String sendData;
-    public VersusCustomizeGetQuizUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String userId, int num, String sendData) {
+    MessageReceiver receiver;
+
+    public VersusCustomizeGetQuizUI(Socket socket, ObjectOutputStream out, String userId, int num, String sendData, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.userId = userId;
         this.num = num;
         this.sendData = sendData;
+        this.receiver = receiver;
 
         JFrame frame = new JFrame("Versus Customize");
         frame.setSize(800, 600);
@@ -60,7 +62,7 @@ public class VersusCustomizeGetQuizUI {
         // 뒤로가기 버튼 동작
         backButton.addActionListener(e -> {
             frame.dispose();
-            new VersusCustomizeUI(socket, out, in, userId);
+            new VersusCustomizeUI(socket, out, userId, receiver);
         });
 
     }
@@ -123,7 +125,7 @@ public class VersusCustomizeGetQuizUI {
                     sendVersusCustomQuizToServer(sendData);
                     JOptionPane.showMessageDialog(frame, "퀴즈 생성이 완료되었습니다.");
                     frame.dispose();
-                    new MenuUI(socket, out, in, userId);  // MenuUI로 돌아감
+                    new MenuUI(socket, out, userId, receiver);  // MenuUI로 돌아감
                 }
             }
         });
@@ -137,7 +139,7 @@ public class VersusCustomizeGetQuizUI {
             out.writeObject(request);
             out.flush();
 
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
             System.out.println("퀴즈 생성 완료 응답 받음");
             String data = response.getData();
 

--- a/src/main/java/client/ui/customize/versusCustomizeUI/VersusCustomizeUI.java
+++ b/src/main/java/client/ui/customize/versusCustomizeUI/VersusCustomizeUI.java
@@ -1,5 +1,6 @@
 package client.ui.customize.versusCustomizeUI;
 
+import client.thread.MessageReceiver;
 import client.ui.GameCustomizeUI;
 import client.ui.icon.ArrowIcon;
 
@@ -12,15 +13,15 @@ import java.net.Socket;
 public class VersusCustomizeUI {
     private final Socket socket;
     private final ObjectOutputStream out;
-    private final ObjectInputStream in;
     private final String userId;
     private String sendData;
+    private MessageReceiver receiver;
 
-    public VersusCustomizeUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, String userId) {
+    public VersusCustomizeUI(Socket socket, ObjectOutputStream out, String userId, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.userId = userId;
+        this.receiver = receiver;
 
         JFrame frame = new JFrame("Versus Customize");
         frame.setSize(800, 600);
@@ -79,7 +80,7 @@ public class VersusCustomizeUI {
         // 뒤로가기 버튼 동작
         backButton.addActionListener(e -> {
             frame.dispose();
-            new GameCustomizeUI(socket, out, in, userId);
+            new GameCustomizeUI(socket, out, userId, receiver);
         });
 
         // 확인 버튼 동작
@@ -88,7 +89,7 @@ public class VersusCustomizeUI {
             String selectedValue = (String) comboBox.getSelectedItem();
             sendData = title+"\n"+selectedValue+"\n";
             frame.dispose();
-            new VersusCustomizeGetQuizUI(socket, out, in, userId, Integer.parseInt(selectedValue),sendData);
+            new VersusCustomizeGetQuizUI(socket, out, userId, Integer.parseInt(selectedValue),sendData, receiver);
         });
 
     }

--- a/src/main/java/client/ui/gamemode/CooperationUI.java
+++ b/src/main/java/client/ui/gamemode/CooperationUI.java
@@ -1,5 +1,6 @@
 package client.ui.gamemode;
 
+import client.thread.MessageReceiver;
 import client.ui.RoomListUI;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
@@ -15,14 +16,12 @@ import java.net.Socket;
 public class CooperationUI {
     private final Socket socket;
     private final ObjectOutputStream out;
-    private final ObjectInputStream in;
     private final int roomId;
     private final String userId;
 
-    public CooperationUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, int roomId, String userId) {
+    public CooperationUI(Socket socket, ObjectOutputStream out, int roomId, String userId, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.roomId = roomId;
         this.userId = userId;
 
@@ -70,7 +69,7 @@ public class CooperationUI {
         // 뒤로가기 버튼 동작
         backButton.addActionListener(e -> {
             frame.dispose();
-            new RoomListUI(socket, out, in, "Cooperation Mode", userId);
+            new RoomListUI(socket, out, "Cooperation Mode", userId, receiver);
         });
 
         // 메시지 전송 동작

--- a/src/main/java/client/ui/gamemode/speedQuiz/StartSpeedQuiz.java
+++ b/src/main/java/client/ui/gamemode/speedQuiz/StartSpeedQuiz.java
@@ -1,0 +1,73 @@
+package client.ui.gamemode.speedQuiz;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class StartSpeedQuiz extends  JFrame {
+    private JLabel questionLabel;
+    private JTextField answerField;
+    private JLabel scoreLabel;
+    private int score = 0;
+
+    public StartSpeedQuiz() {
+        setTitle("Speed Quiz");
+        setSize(400,300);
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(null);
+        getContentPane().setBackground(new Color(255, 247, 204)); // 배경색 설정
+
+        // 로고
+        JLabel logoLabel = new JLabel(new ImageIcon("./src/main/java/client/ui/nesquick_logo.png"));
+        logoLabel.setBounds(10, 10, 80, 40);
+        add(logoLabel);
+
+        // 현재 점수 표시
+        scoreLabel = new JLabel("현재 스코어 : 0점");
+        scoreLabel.setBounds(300, 10, 100, 30);
+        add(scoreLabel);
+
+        // 문제 표시
+        questionLabel = new JLabel("Q1. 사과를 한 입 베어 먹으면?");
+        questionLabel.setBounds(50, 80, 300, 30);
+        questionLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        questionLabel.setOpaque(true);
+        questionLabel.setBackground(new Color(255, 255, 204));
+        add(questionLabel);
+
+        // 답 입력 필드
+        answerField = new JTextField();
+        answerField.setBounds(120, 150, 150, 30);
+        add(answerField);
+
+        // 정답 버튼
+        JButton submitButton = new JButton("정답");
+        submitButton.setBounds(150, 200, 80, 30);
+        submitButton.setBackground(new Color(255, 223, 85));
+        add(submitButton);
+
+        // 정답 버튼 클릭 시 동작
+        submitButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                checkAnswer(answerField.getText().trim());
+            }
+        });
+
+        setVisible(true);
+    }
+
+    // 정답 체크
+    private void checkAnswer(String answer) {
+        if (answer.equals("사과")) { // 예시 정답
+            score += 10;
+            JOptionPane.showMessageDialog(this, "정답입니다!");
+            scoreLabel.setText("현재 스코어 : " + score + "점");
+            // 다음 문제로 이동하는 로직 추가 가능
+        } else {
+            JOptionPane.showMessageDialog(this, "오답입니다. 다시 시도하세요!");
+        }
+        answerField.setText("");
+    }
+}

--- a/src/main/java/client/ui/gamemode/versusUI/VersusRankingUI.java
+++ b/src/main/java/client/ui/gamemode/versusUI/VersusRankingUI.java
@@ -1,5 +1,6 @@
 package client.ui.gamemode.versusUI;
 
+import client.thread.MessageReceiver;
 import client.ui.RoomListUI;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
@@ -14,18 +15,18 @@ import java.util.List;
 public class VersusRankingUI {
     private final Socket socket;
     private final ObjectOutputStream out;
-    private final ObjectInputStream in;
     private final int roomId;
     private final String userId;
     private List<String> ranking;
+    private MessageReceiver receiver;
 
-    public VersusRankingUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, int roomId, String userId, List<String> ranking) {
+    public VersusRankingUI(Socket socket, ObjectOutputStream out, int roomId, String userId, List<String> ranking, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.roomId = roomId;
         this.userId = userId;
         this.ranking = ranking;
+        this.receiver = receiver;
 
         JFrame frame = new JFrame("VersusRanking");
         frame.setSize(800, 600);
@@ -69,7 +70,7 @@ public class VersusRankingUI {
         backButton.addActionListener(e -> {
             outRoom(roomId);
             frame.dispose();
-            new RoomListUI(socket, out, in, "Versus Mode", this.userId);
+            new RoomListUI(socket, out, "Versus Mode", this.userId, receiver);
         });
 
     }
@@ -81,7 +82,7 @@ public class VersusRankingUI {
                     .setData(String.valueOf(roomId));
             out.writeObject(outRequest);
 
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
             System.out.println(response);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/client/ui/gamemode/versusUI/VersusStartUI.java
+++ b/src/main/java/client/ui/gamemode/versusUI/VersusStartUI.java
@@ -1,5 +1,6 @@
 package client.ui.gamemode.versusUI;
 
+import client.thread.MessageReceiver;
 import client.ui.RoomListUI;
 import client.ui.icon.ArrowIcon;
 import protocol.Message;
@@ -17,19 +18,19 @@ import java.util.List;
 public class VersusStartUI {
     private final Socket socket;
     private final ObjectOutputStream out;
-    private final ObjectInputStream in;
     private final int roomId;
     private final String userId;
     private List<Quiz> quizList;
     private int score=0;
+    private MessageReceiver receiver;
 
-    public VersusStartUI(Socket socket, ObjectOutputStream out, ObjectInputStream in, int roomId, String userId, List<Quiz> quizList) {
+    public VersusStartUI(Socket socket, ObjectOutputStream out, int roomId, String userId, List<Quiz> quizList, MessageReceiver receiver) {
         this.socket = socket;
         this.out = out;
-        this.in = in;
         this.roomId = roomId;
         this.userId = userId;
         this.quizList = quizList;
+        this.receiver = receiver;
 
         JFrame frame = new JFrame("Versus Start");
         frame.setSize(800, 600);
@@ -64,7 +65,7 @@ public class VersusStartUI {
         // 뒤로가기 버튼 동작
         backButton.addActionListener(e -> {
             frame.dispose();
-            new RoomListUI(socket, out, in, "Versus Mode", userId);
+            new RoomListUI(socket, out, "Versus Mode", userId, receiver);
         });
 
     }
@@ -118,7 +119,7 @@ public class VersusStartUI {
                     JOptionPane.showMessageDialog(frame, "퀴즈가 종료되었습니다!\n최종 점수: " + score);
                     List<String> list = fetchVersusRankingFromServer();
                     frame.dispose();
-                    new VersusRankingUI(socket, out, in, roomId, userId, list);
+                    new VersusRankingUI(socket, out, roomId, userId, list, receiver);
                 }
             }
         });
@@ -134,7 +135,7 @@ public class VersusStartUI {
             out.writeObject(request);
             out.flush();
 
-            Message response = (Message) in.readObject();
+            Message response = receiver.takeMessage();
 
             String data = response.getData();
             String tmp[] = data.split("\n");

--- a/src/main/java/protocol/Message.java
+++ b/src/main/java/protocol/Message.java
@@ -13,6 +13,7 @@ public class Message implements Serializable {
 
     private String roomName;
     private int roomId;
+    private String roomMaster;
     private Map<Integer, String> roomNames;
     private int capacity;
     private String data; //Message body
@@ -56,6 +57,8 @@ public class Message implements Serializable {
     public int getRoomId() {
         return roomId;
     }
+
+    public String getRoomMaster() {return roomMaster;}
 
     public Message setRoomId(int roomId) {
         this.roomId = roomId;
@@ -101,5 +104,9 @@ public class Message implements Serializable {
         this.roomNames = roomNames;
         return this;
     }
-}
 
+    public Message setRoomMaster(String roomMaster) {
+        this.roomMaster = roomMaster;
+        return this;
+    }
+}


### PR DESCRIPTION
클라이언트 로직에서 스레드 분기가 일어나서 ObjectInputStream.readObject()을 사용하게 되면 메인 스레드의 ObjectInputStream.readObject()와 충돌이 나는 것을 확인했습니다.

따라서, 서버로부터 Message 객체를 읽어들이는 스레드인 MessageRecevier를 통해서 모든 클라이언트 로직이 Message를 수신하도록 수정하였습니다. 
> 방에서_ 나갈때는 항상!! 스레드를 종료시키고 나갈 수 있도록 해주세요. 아니면 데드락이 발생하면서 화면이 종료되는 현상이 일어납니다